### PR TITLE
fix navigation error

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,7 +35,7 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: Scaffold(
+      home: Builder(builder: (context) => Scaffold(
         appBar: AppBar(
           title: Text('List Appp'),
           actions: <Widget>[
@@ -69,7 +69,7 @@ class _MyAppState extends State<MyApp> {
             },
           ),
         ),
-      ),
+      ),)
     );
   }
 }


### PR DESCRIPTION
you cant just do navigation directly from MaterialApp, use Builder as a parent of Scaffold or create another widget class and pass it to the MaterialApp(home: //here)